### PR TITLE
Avoid stack overflows on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,12 @@
+[target.x86_64-pc-windows-msvc]
+# Increase default stack size to avoid running out of stack
+# space in debug builds. The size matches Linux's default.
+rustflags = [
+    "-C", "link-arg=/STACK:8000000"
+]
+[target.aarch64-pc-windows-msvc]
+# Increase default stack size to avoid running out of stack
+# space in debug builds. The size matches Linux's default.
+rustflags = [
+    "-C", "link-arg=/STACK:8000000"
+]


### PR DESCRIPTION
Apply the guidance from https://docs.slint.dev/latest/docs/slint/guide/platforms/desktop/#rust-stack-overflows